### PR TITLE
log4j config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ services:
 - docker
 env:
   global:
-  - DOCKER_VERSION=1.11.2-0~trusty
-  - DOCKER_COMPOSE_VERSION=1.8.0-rc2
+  - DOCKER_VERSION=1.12.0-0~trusty
+  - DOCKER_COMPOSE_VERSION=1.8.0
   - ORG=${TRAVIS_REPO_SLUG%/*}
   - REPO=${TRAVIS_REPO_SLUG##*-}
   - TAG=${TRAVIS_TAG:-${TRAVIS_COMMIT:0:7}}

--- a/fs/etc/hadoop/conf/log4j.properties
+++ b/fs/etc/hadoop/conf/log4j.properties
@@ -1,0 +1,6 @@
+hadoop.root.logger=INFO, console
+log4j.rootLogger = INFO, console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.out
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{2}: %m%n


### PR DESCRIPTION
This gets rid of log4j log spam:

```
accumulo-tserver_1  | log4j:WARN No appenders could be found for logger (org.apache.hadoop.util.Shell).
accumulo-tserver_1  | log4j:WARN Please initialize the log4j system properly.
accumulo-tserver_1  | log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
```
